### PR TITLE
stickers: added back sticker information (the download is still broken)

### DIFF
--- a/hitsuki/modules/stickers.py
+++ b/hitsuki/modules/stickers.py
@@ -40,7 +40,7 @@ async def get_sticker(message, strings):
     await message.reply_document(
         InputFile(sticker_file,
                   filename=f'{sticker.set_name}_{sticker.file_id[:5]}.png'),
-        text
+        caption=text
     )
 
 


### PR DESCRIPTION
The broken download only happens in the local Bots API, tested on
tdlight only.